### PR TITLE
LD4P-28 - testing github-youtrack integration for chrome

### DIFF
--- a/test-commit-file.txt
+++ b/test-commit-file.txt
@@ -1,0 +1,1 @@
+testing-github-youtrack-LD4P-28


### PR DESCRIPTION
This PR will be discarded.  It is simply a test of the github-youtrack integration plugin for Chrome.

Fix LD4P-28

- when the plugin is working, the `LD4P-28` will be a link
- hovering over the link will show a pop-up summary of the issue
- it doesn't work with the really neat github auto-complete features, too bad
- it only works when loading or reloading the page, it doesn't update after editing this panel