### PR TITLE
Metrics Example Implementation using metrics-scala

### DIFF
--- a/Demos/SingleMetricExample/src/main/scala/SingleMetricExample.scala
+++ b/Demos/SingleMetricExample/src/main/scala/SingleMetricExample.scala
@@ -1,0 +1,55 @@
+import scala.io.StdIn
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Failure, Success, Random}
+
+import com.codahale.metrics.ConsoleReporter
+import java.util.concurrent.TimeUnit;
+
+object OurApplication { // These would be extracted to be common to all our subprojects
+  val metricRegistry = new com.codahale.metrics.MetricRegistry()
+}
+trait Instrumented extends nl.grons.metrics.scala.InstrumentedBuilder {
+  val metricRegistry = OurApplication.metricRegistry
+}
+
+object SingleMetricExample extends Instrumented {
+  val generator = new Random
+  private[this] val loading = metrics.timer("execution")
+  val reporter = ConsoleReporter.forRegistry(metricRegistry)
+                                .convertRatesTo(TimeUnit.SECONDS)
+                                .convertDurationsTo(TimeUnit.MILLISECONDS)
+                                .build()
+
+  // Sleeps 0, 1, 2 or 3 seconds randomly to simulate varying execution times
+  def asyncDoIt(i: Int): Future[Int] = {
+    val duration: Int = generator.nextInt(4)
+    Future {
+      println(s"  Sleeping $i for " + duration.toString)
+      Thread.sleep(duration * 1000)
+      duration
+    }
+  }
+
+  def doIt(i: Int): Future[Int] = loading.timeFuture {
+    asyncDoIt(i)
+  }
+
+  def main(args: Array[String]) {
+    reporter.start(10, TimeUnit.SECONDS)
+    (1 to 10)
+      .map(elem => { println(s"before: $elem"); elem })
+      .map(elem => {
+        val f = doIt(elem)
+        f onComplete {
+          case Success(t) => println(s"    Elem $elem slept for " + t.toString)
+          case Failure(t) => println("An error has occured: " + t.getMessage)
+        }
+        elem
+      })
+
+    println("\nOutputting metrics every 10 seconds, or press 'return' to exit.\n")
+    StdIn.readLine() // Wait, to avoid closing the chain before the Futures complete
+    reporter.stop
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -18,34 +18,30 @@ lazy val commonSettings = Seq (
 
 lazy val `ld4p-data-pipeline` = (project in file("."))
   .settings(commonSettings)
-
-  .aggregate( SparkStreamingConvertors, reactiveConsumers, reactiveProducers,
+  .aggregate(sparkStreamingConvertors, reactiveConsumers, reactiveProducers,
     tools, demos
   )
 
+val sparkStreamingConvertorsName  = "SparkStreamingConvertors"
+lazy val sparkStreamingConvertors = ld4pProjects(sparkStreamingConvertorsName).aggregate(m21toBibFDumpConvApp, m21toBibFContinousConvApp)
 
+val consumersProjectName   = "ReactiveConsumers"
+lazy val reactiveConsumers = ld4pProjects(consumersProjectName).aggregate(ReactiveKafkaConsumer)
 
-val sparkStreamingConvertors      = "SparkStreamingConvertors"
-lazy val SparkStreamingConvertors = ld4pProjects(sparkStreamingConvertors).aggregate(m21toBibFDumpConvApp, m21toBibFContinousConvApp)
+val producerProjectName    = "ReactiveProducers"
+lazy val reactiveProducers = ld4pProjects(producerProjectName).aggregate(ReactiveKafkaProducer)
 
-val consumersProjectName    = "ReactiveConsumers"
-lazy val reactiveConsumers  = ld4pProjects(consumersProjectName).aggregate(ReactiveKafkaConsumer)
+val toolProjectName        = "Tools"
+lazy val tools             = ld4pProjects(toolProjectName).aggregate(AkkaStreamMarcReader)
 
-val producerProjectName      = "ReactiveProducers"
-lazy val reactiveProducers  = ld4pProjects(producerProjectName).aggregate(ReactiveKafkaProducer)
-
-val toolProjectName         = "Tools"
-lazy val tools              = ld4pProjects(toolProjectName).aggregate(AkkaStreamMarcReader)
-
-val demoProjectName         = "Demos"
-lazy val demos              = ld4pProjects(demoProjectName).aggregate(estimator, estimatorStreaming, marcXMLtoBibFrame, ReactiveFolderCopier, ReactiveFolderReader)
-
+val demoProjectName        = "Demos"
+lazy val demos             = ld4pProjects(demoProjectName).aggregate(estimator, estimatorStreaming, marcXMLtoBibFrame, ReactiveFolderCopier, ReactiveFolderReader, singleMetricExample)
 
 /**
   *  The Concrete Projects Applications
   */
 
-lazy val m21toBibFDumpConvApp = ld4pProjects(sparkStreamingConvertors + "/M21toBibFDumpConvApp")
+lazy val m21toBibFDumpConvApp = ld4pProjects(sparkStreamingConvertorsName + "/M21toBibFDumpConvApp")
   .settings(
     commonSettings,
     libraryDependencies ++= Seq(
@@ -68,8 +64,7 @@ lazy val m21toBibFDumpConvApp = ld4pProjects(sparkStreamingConvertors + "/M21toB
     mainClass in assembly := Some("M21toBibFDumpConvApp")
   )
 
-
-lazy val m21toBibFContinousConvApp =   ld4pProjects(sparkStreamingConvertors + "/M21toBibFContinousConvApp")
+lazy val m21toBibFContinousConvApp = ld4pProjects(sparkStreamingConvertorsName + "/M21toBibFContinousConvApp")
   .settings(
     commonSettings,
     libraryDependencies ++= Seq(
@@ -90,12 +85,7 @@ lazy val m21toBibFContinousConvApp =   ld4pProjects(sparkStreamingConvertors + "
     mainClass in assembly := Some("M21toBibFContinousConvApp")
 )
 
-
-
-
-
-
-//Simple function to help pick banana dependency. Nothing fency
+// Simple function to help pick banana dependency. Nothing fency
 val banana = (name: String) => "org.w3" %% name % "0.8.4" excludeAll (ExclusionRule(organization = "org.scala-stm"))
 
 lazy val ReactiveKafkaConsumer = ld4pProjects(consumersProjectName + "/ReactiveKafkaConsumer")
@@ -115,7 +105,7 @@ lazy val ReactiveKafkaConsumer = ld4pProjects(consumersProjectName + "/ReactiveK
     mainClass in assembly := Some("ReactiveKafkaStardogConsumer")
   )
 
-lazy val ReactiveKafkaProducer   = ld4pProjects(producerProjectName + "/ReactiveKafkaProducer")
+lazy val ReactiveKafkaProducer = ld4pProjects(producerProjectName + "/ReactiveKafkaProducer")
   .settings(
     commonSettings,
     libraryDependencies ++= Seq(
@@ -125,14 +115,14 @@ lazy val ReactiveKafkaProducer   = ld4pProjects(producerProjectName + "/Reactive
       "com.typesafe.akka" %% "akka-stream-testkit" % "2.5.4" % Test,
       "com.github.pathikrit" %% "better-files" % "2.17.1"
     ),
-    mainClass in assembly := Some("ReactiveKafkaFsProducer")
+    mainClass in assembly := Some("ReactiveKafkaProducer")
   )
 
 /**
   *  Tools & Demos
   */
 
-lazy val estimator             = ld4pProjects(demoProjectName + "/EstimatorApp")
+lazy val estimator = ld4pProjects(demoProjectName + "/EstimatorApp")
   .settings(
     commonSettings,
     libraryDependencies ++= Seq(
@@ -149,7 +139,7 @@ lazy val estimator             = ld4pProjects(demoProjectName + "/EstimatorApp")
     mainClass in assembly := Some("EstimatorApp")
   )
 
-lazy val estimatorStreaming    = ld4pProjects(demoProjectName + "/EstimatorStreamingApp")
+lazy val estimatorStreaming = ld4pProjects(demoProjectName + "/EstimatorStreamingApp")
   .settings(
     commonSettings,
     libraryDependencies ++= Seq(
@@ -166,8 +156,7 @@ lazy val estimatorStreaming    = ld4pProjects(demoProjectName + "/EstimatorStrea
     mainClass in assembly := Some("EstimatorStreamingApp")
   )
 
-
-lazy val marcXMLtoBibFrame     = ld4pProjects(demoProjectName + "/MarcXMLtoBibFrame")
+lazy val marcXMLtoBibFrame = ld4pProjects(demoProjectName + "/MarcXMLtoBibFrame")
   .settings(
     commonSettings,
     libraryDependencies ++= Seq(
@@ -182,7 +171,7 @@ lazy val marcXMLtoBibFrame     = ld4pProjects(demoProjectName + "/MarcXMLtoBibFr
     mainClass in assembly := Some("MarcXMLtoBibFrame")
   )
 
-lazy val ReactiveFolderCopier  = ld4pProjects(demoProjectName + "/ReactiveFolderCopier")
+lazy val ReactiveFolderCopier = ld4pProjects(demoProjectName + "/ReactiveFolderCopier")
   .settings(
     commonSettings,
     libraryDependencies ++= Seq(
@@ -195,7 +184,7 @@ lazy val ReactiveFolderCopier  = ld4pProjects(demoProjectName + "/ReactiveFolder
     mainClass in assembly := Some("ReactiveFolderCopier")
   )
 
-lazy val ReactiveFolderReader  = ld4pProjects(demoProjectName + "/ReactiveFolderReader")
+lazy val ReactiveFolderReader = ld4pProjects(demoProjectName + "/ReactiveFolderReader")
   .settings(
     commonSettings,
     libraryDependencies ++= Seq(
@@ -207,11 +196,16 @@ lazy val ReactiveFolderReader  = ld4pProjects(demoProjectName + "/ReactiveFolder
     mainClass in assembly := Some("ReactiveFolderReader")
   )
 
+lazy val singleMetricExample = ld4pProjects(demoProjectName + "/SingleMetricExample")
+  .settings(
+    commonSettings,
+    mainClass in assembly := Some("SingleMetricExample")
+  )
 
 /**
   * Tools
   */
-lazy val AkkaStreamMarcReader  = ld4pProjects(toolProjectName + "/AkkaStreamMarcReader")
+lazy val AkkaStreamMarcReader = ld4pProjects(toolProjectName + "/AkkaStreamMarcReader")
   .settings(
     commonSettings,
     libraryDependencies ++= Seq (

--- a/build.sbt
+++ b/build.sbt
@@ -1,22 +1,20 @@
 
-
-
 def ld4pProjects(pathName: String): Project = (Project(pathName.split("/").last, file(pathName)))
-
 
 lazy val commonSettings = Seq (
   organization:= "edu.stanford.library",
   version := "1.0.0-SNAPSHOT",
   scalaVersion := "2.11.11",
-  libraryDependencies ++= Seq("com.typesafe" % "config" % "1.3.1",
-    "com.github.kxbmap" %% "configs" % "0.4.4"
-    ),
+  libraryDependencies ++= Seq(
+    "com.typesafe" % "config" % "1.3.1",
+    "com.github.kxbmap" %% "configs" % "0.4.4",
+    "nl.grons" %% "metrics-scala" % "3.5.9_a2.3",
+    "org.scalatest" %% "scalatest" % "3.0.1" % Test
+  ),
   resolvers += "bblfish-snapshots" at "http://bblfish.net/work/repo/releases"
-
-  //If you want to run with Provided dependency
-  //run in Compile := Defaults.runTask(fullClasspath in Compile, mainClass in (Compile, run), runner in (Compile, run)).evaluated
+  // If you want to run with Provided dependency
+  // run in Compile := Defaults.runTask(fullClasspath in Compile, mainClass in (Compile, run), runner in (Compile, run)).evaluated
 )
-
 
 lazy val `ld4p-data-pipeline` = (project in file("."))
   .settings(commonSettings)


### PR DESCRIPTION
Running `SingleMetricExample` includes output like:
```
-- Timers ----------------------------------------------------------------------
SingleMetricExample.execution
             count = 10
         mean rate = 1.00 calls/second
     1-minute rate = 1.84 calls/second
     5-minute rate = 1.97 calls/second
    15-minute rate = 1.99 calls/second
               min = 2.22 milliseconds
               max = 2004.69 milliseconds
              mean = 1215.66 milliseconds
            stddev = 746.12 milliseconds
            median = 1020.90 milliseconds
              75% <= 2002.92 milliseconds
              95% <= 2004.69 milliseconds
              98% <= 2004.69 milliseconds
              99% <= 2004.69 milliseconds
            99.9% <= 2004.69 milliseconds
```

Future work could:
- decouple the outputter and the thing being measured into separate objects
- extract MetricRegistry code to common App for use by all subprojects
- add additional metric types
- investigate multi-step metrics ("lap 1, lap 2, lap 3...") and the composition of a single "duration" from endpoints in separate pieces of code (not amenable to the basic `timer` approach).