### PR TITLE
Uses the catDump script to source the sirsi.env on symphony

### DIFF
--- a/ReactiveProducers/ReactiveKafkaProducer/src/main/scala/ReactiveKafkaSymphonyProducer.scala
+++ b/ReactiveProducers/ReactiveKafkaProducer/src/main/scala/ReactiveKafkaSymphonyProducer.scala
@@ -70,7 +70,7 @@ object ReactiveKafkaSymphonyProducer extends App {
       }
       case Some(e) => {
         if (e == "symphony")
-          (s"cat ${file}" #| "/s/sirsi/Unicorn/Bin/catalogdump -om -kc -h 2>/dev/null").run(processIO)
+          s"ssh -K sirsi@morison.stanford.edu /s/SUL/Bin/LD4P/catDump.sh ${file}".run(processIO)
         else
           println("Any second argument will do, but usage should really be: ReactiveKafkaSymphonyProducer [ckey_file] symphony")
       }


### PR DESCRIPTION
The script is under `/s/SUL/Bin/LD4P/catDump.sh` on Morison:

```
#!/bin/bash

source /s/SUL/Config/sirsi.env

cat $1 | /s/sirsi/Unicorn/Bin/catalogdump -om -kc 2> /s/SUL/Dataload/LD4P/catDump.log
```