### PR TITLE
Install sbt and assemble the spark projects

### DIFF
--- a/lib/bash/debian/sbt.sh
+++ b/lib/bash/debian/sbt.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if which sbt > /dev/null; then
+    echo "Found sbt installation"
+else
+    echo "sbt installation"
+    if [ ! -f /etc/apt/sources.list.d/sbt.list ]; then
+        echo "deb https://dl.bintray.com/sbt/debian /" > /etc/apt/sources.list.d/sbt.list
+        apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
+        apt-get -y -qq update
+    fi
+    apt-get install -y -qq sbt
+fi

--- a/lib/bash/redhat/sbt.sh
+++ b/lib/bash/redhat/sbt.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# http://www.scala-sbt.org/release/docs/Installing-sbt-on-Linux.html
+
+if which sbt > /dev/null; then
+    echo "Found sbt installation"
+else
+    echo "sbt installation"
+    if [ ! -f /etc/yum.repos.d/bintray-sbt-rpm.repo ]; then
+        curl https://bintray.com/sbt/rpm/rpm | sudo tee /etc/yum.repos.d/bintray-sbt-rpm.repo
+    fi
+    sudo yum install -y sbt
+fi

--- a/lib/capistrano/tasks/spark.rake
+++ b/lib/capistrano/tasks/spark.rake
@@ -1,8 +1,8 @@
 namespace :spark do
 
   after :deploy, 'spark:update_env'
+  after :deploy, 'spark:assembly'
 
-  # Set the /etc/environment
   desc 'Update the spark environment variables'
   task :update_env do
     on roles(:spark) do
@@ -13,6 +13,14 @@ namespace :spark do
       execute("echo 'export LD4P_DATA=#{fetch(:ld4p_data)}' | sudo tee -a /etc/environment > /dev/null")
       execute("echo 'export BOOTSTRAP_SERVERS=#{fetch(:bootstrap_servers)}' | sudo tee -a /etc/environment > /dev/null")
       execute("echo '### END_LD4P_ENV' | sudo tee -a /etc/environment > /dev/null")
+    end
+  end
+
+  desc 'sbt SparkStreamingConvertors/assembly'
+  task :assembly do
+    on roles(:spark) do
+      sudo("#{current_path}/lib/bash/redhat/sbt.sh")
+      execute("cd #{current_path}; sbt SparkStreamingConvertors/assembly")
     end
   end
 


### PR DESCRIPTION
This is a partial solution for #21 to assemble the spark streaming app on the spark cluster.

This capistrano task assembles the spark app on the spark nodes. The first time it runs, it has to install sbt and the first time sbt runs it has to download and cache all the dependencies for the build system and the project. Once that is all done once, it is cached on each node and all subsequent assemblies are very quick.  (A previous solution to this problem built the uber-jar locally and uploaded them, but they took forever to upload.  The solution in this PR is better.)

I've done the integration test on this, fixed all the bugs, and it works.
