### PR TITLE
Stardog deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,3 +204,11 @@ bundle exec cap ld4p_dev deploy:check
 bundle exec cap ld4p_dev deploy
 bundle exec cap ld4p_dev shell
 ```
+
+Once the project is deployed to all the servers, run the assembly task for
+a project, e.g.
+```bash
+bundle exec cap ld4p_dev spark:assembly
+bundle exec cap ld4p_dev stardog:assembly
+```
+

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -7,6 +7,13 @@ ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
 # Default deploy_to directory is /var/www/my_app_name
 set :deploy_to, "/opt/ld4p-data-pipeline"
 
+before 'deploy:check:directories', 'deploy:mkdir_deploy_to' do
+  on roles(:all) do
+    execute("[ -d #{fetch(:deploy_to)} ] || sudo mkdir -p #{fetch(:deploy_to)}")
+    execute("sudo chmod a+w #{fetch(:deploy_to)}")
+  end
+end
+
 # Default value for :format is :airbrussh.
 # set :format, :airbrussh
 

--- a/config/deploy/ld4p_dev.rb
+++ b/config/deploy/ld4p_dev.rb
@@ -8,7 +8,7 @@ server 'ld4p_dev_spark_worker2', user: 'root', roles: %w{redhat spark worker}
 server 'ld4p_dev_spark_worker3', user: 'root', roles: %w{redhat spark worker}
 
 # stardog
-server 'ld4p_dev_stardog', user: 'root', roles: %w{redhat stardog triplestore}
+server 'ld4p_dev_stardog', user: 'ubuntu', roles: %w{ubuntu stardog triplestore}
 
 # ----
 # Setup the environment variables

--- a/config/deploy/ld4p_dev.rb
+++ b/config/deploy/ld4p_dev.rb
@@ -7,8 +7,11 @@ server 'ld4p_dev_spark_worker1', user: 'root', roles: %w{redhat spark worker}
 server 'ld4p_dev_spark_worker2', user: 'root', roles: %w{redhat spark worker}
 server 'ld4p_dev_spark_worker3', user: 'root', roles: %w{redhat spark worker}
 
+# stardog
+server 'ld4p_dev_stardog', user: 'root', roles: %w{redhat stardog triplestore}
+
 # ----
-# Setup the environment variables for the spark app
+# Setup the environment variables
 
 set :ld4p_data, File.join(fetch(:deploy_to), 'current', 'src', 'main', 'resources', 'xsl')
 set :bootstrap_servers, 'ec2-34-213-81-65.us-west-2.compute.amazonaws.com:9092,ec2-34-214-42-7.us-west-2.compute.amazonaws.com:9092,ec2-52-36-184-167.us-west-2.compute.amazonaws.com:9092'

--- a/lib/capistrano/tasks/spark.rake
+++ b/lib/capistrano/tasks/spark.rake
@@ -1,7 +1,6 @@
 namespace :spark do
 
   after :deploy, 'spark:update_env'
-  after :deploy, 'spark:assembly'
 
   desc 'Update the spark environment variables'
   task :update_env do

--- a/lib/capistrano/tasks/stardog.rake
+++ b/lib/capistrano/tasks/stardog.rake
@@ -19,7 +19,7 @@ namespace :stardog do
   desc 'sbt ReactiveKafkaConsumer/assembly'
   task :assembly do
     on roles(:stardog) do
-      sudo("#{current_path}/lib/bash/redhat/sbt.sh")
+      sudo("#{current_path}/lib/bash/debian/sbt.sh")
       execute("cd #{current_path}; sbt ReactiveKafkaConsumer/assembly")
     end
   end

--- a/lib/capistrano/tasks/stardog.rake
+++ b/lib/capistrano/tasks/stardog.rake
@@ -1,7 +1,6 @@
 namespace :stardog do
 
   after :deploy, 'stardog:update_env'
-  after :deploy, 'stardog:assembly'
 
   desc 'Update the Stardog environment variables'
   task :update_env do

--- a/lib/capistrano/tasks/stardog.rake
+++ b/lib/capistrano/tasks/stardog.rake
@@ -1,0 +1,27 @@
+namespace :stardog do
+
+  after :deploy, 'stardog:update_env'
+  after :deploy, 'stardog:assembly'
+
+  desc 'Update the Stardog environment variables'
+  task :update_env do
+    on roles(:stardog) do
+      # remove any existing entries
+      sudo("sed -i -e '/BEGIN_LD4P_ENV/,/END_LD4P_ENV/{ d; }' /etc/environment")
+      # append new entries
+      execute("echo '### BEGIN_LD4P_ENV' | sudo tee -a /etc/environment > /dev/null")
+      execute("echo 'export LD4P_DATA=#{fetch(:ld4p_data)}' | sudo tee -a /etc/environment > /dev/null")
+      execute("echo 'export BOOTSTRAP_SERVERS=#{fetch(:bootstrap_servers)}' | sudo tee -a /etc/environment > /dev/null")
+      execute("echo '### END_LD4P_ENV' | sudo tee -a /etc/environment > /dev/null")
+    end
+  end
+
+  desc 'sbt ReactiveKafkaConsumer/assembly'
+  task :assembly do
+    on roles(:stardog) do
+      sudo("#{current_path}/lib/bash/redhat/sbt.sh")
+      execute("cd #{current_path}; sbt ReactiveKafkaConsumer/assembly")
+    end
+  end
+
+end


### PR DESCRIPTION
This is a partial resolution for #21 

The deploy phase is working fine, but the assembly phase is failing at the moment because the dependency on banana-rdf is not available.  That's not necessarily a failure of this deployment, but rather a failure to resolve the publication of that dependency.  At present, I think this PR is good enough to go.

With the assembly tasks separated from the deployment, it should succeed OK and do so quickly.  We want to separate these assembly tasks because we don't _always_ want to rebuild every project that gets deployed from this multi-project application.  We need to be able to deploy everything and selectively assemble the projects that have changed.

@Maatary - for the demo, use your custom stardog scp because there are problems with banana-rdf that need to be solved later.  @atz submitted an issue to get it published and they did it, see https://github.com/banana-rdf/banana-rdf/issues/328; so @Maatary - we need to use that published artifact; are we using it or not?
 
@Maatary - you must review the environment variables required for the stardog project, so please review PR 30 in that regard.  You mentioned some additional env values that need to be set and I don’t know what they are.
